### PR TITLE
Remove quality role link from marketing homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,6 @@ title: Products and services
 <h2><a href="https://about.publiccode.net/roles/">Open positions, come work with us!</a></h2>
 
 <div class="mp-cards">
-  <a href="https://about.publiccode.net/roles/quality.html" class="mp-card">
-    <h5 class="type">Full time, Amsterdam</h5>
-    <h3 class="title">Codebase steward for quality</h3>
-    <p>Help developers build high quality Public Code.</p>
-  </a>
   <a href="https://about.publiccode.net/roles/community.html" class="mp-card">
     <h5 class="type">Full time, Amsterdam</h5>
     <h3 class="title">Codebase steward for community</h3>


### PR DESCRIPTION
This is ready for when we decide to close this role.