### PR TITLE
MVP updated stewardship text (bugfix)

### DIFF
--- a/codebase-stewardship/index.html
+++ b/codebase-stewardship/index.html
@@ -3,19 +3,13 @@ layout: marketing-page
 title: Codebase Stewardship
 ---
 
-<div class="product-status">
-  <p><strong>This service is still in development</strong>, all information on this page should be considered informative and non-actionable.</p>
-</div>
-
 <div class="mp-section">
   <div>
     <h1 class="title">Codebase stewardship</h1>
     <h1>Everything your project needs to be sustainable, collaborative and open.</h1>
 
     <p>
-      Through <strong>Codebase stewardship</strong> we help public source code & policy
-      code products become successful by guaranteeing their marketability and
-      quality. Trustworthy, usable, maintained and sustainable code & code for your city.
+      Through <strong>codebase stewardship</strong> we help public-purpose open source codebases become successful by guaranteeing their quality and marketability. Trustworthy, usable, maintained and sustainable public code for your public organization.
     </p>
   </div>
 
@@ -26,7 +20,7 @@ title: Codebase Stewardship
   <div><h2>Making sure the code, tests and documentation are always up to the standards</h2>
 
   <p>
-    We check every merge request on code, policy and documentation quality in our <strong>codebase auditing</strong> process. This enables agile development for trustworthy codebases for public institutions and their collaborators.
+    We check every merge request on code, policy and documentation quality in our <strong>codebase auditing</strong> process. This enables agile development for trustworthy codebases for public organizations and their collaborators.
   </p>
   </div>
   <img alt="illustration, checking" src="/brand-assets/passport-check.svg">
@@ -36,7 +30,7 @@ title: Codebase Stewardship
   <div><h2>Enabling the community to grow, organize and build amazing things together</h2>
 
   <p>
-    With <strong>community development</strong> we help the community organize and grow, to process feedback and contributions, organize events, and build and execute effective governance.
+    With <strong>community development</strong> we help the community organize and grow, process feedback and contributions, host events, and build and execute effective governance.
   </p>
   </div>
   <img alt="illustration, conversation" src="/brand-assets/woman-conversation.svg">
@@ -46,7 +40,7 @@ title: Codebase Stewardship
   <div><h2>Adding the stories and details a codebase needs to be noticed and re-used</h2>
 
   <p>
-    Through <strong>product management</strong> we grow adoption and help mature the codebase to the point where it can shine on its own. In order for potential re-users and future contributors to notice and adopt the codebase we help to turn it in to a product with the branding and communications it needs as well as support on development and design.
+    Through <strong>product management</strong> we grow adoption and help mature the codebase to the point where it can shine on its own. So potential re-users and future contributors notice and adopt the codebase, we help turn it in to a product with strong branding and communications. We also support on development and design.
   </p>
   </div>
   <img alt="illustration, designer" src="/brand-assets/deadline.svg">
@@ -66,7 +60,7 @@ title: Codebase Stewardship
   <div><h2>We take care of the product and codebase's operations and legal affairs</h2>
 
   <p>
-    In order to effectively steward a codebase we provide operations support such as infrastructure and process management as well as legal services such as license support, IP management and trademark protection.
+    To effectively steward a codebase, we provide operations support such as infrastructure and process management as well as legal services such as license support, IP management and trademark protection.
   </p>
   </div>
   <img alt="illustration, support" src="/brand-assets/man-designer.svg">


### PR DESCRIPTION
These are minimal changes to:

- remove the banner warning that we're not yet doing stewardship
- update out of date language so it matches our statements in other places

It doesn't change:

- the salesy tone
- the substantive description of what we offer in stewardship
- the images